### PR TITLE
use `gte` and `lte` insted of `start` and `end`

### DIFF
--- a/lib/level-geospatial.js
+++ b/lib/level-geospatial.js
@@ -93,8 +93,8 @@ module.exports = function(db){
       //console.log("http://ak.dynamic.t1.tiles.virtualearth.net/comp/ch/" + quadKey + "?mkt=en-gb&it=G,VE,BX,L,LA&shading=hill&og=18&n=z");
 
       var options = {}
-      options.start = "geos~" + quadKey;
-      options.end =  "geos~" + quadKey + "~";
+      options.gte = "geos~" + quadKey;
+      options.lte =  "geos~" + quadKey + "~";
       openStreams++;
 
       db.createReadStream(options)


### PR DESCRIPTION
## Abstruct

levelup's `db.createReadStream` range option `start` and `end` has removed in v5.0.0

Now this library cause an error:
```
Error: Legacy range options ("start" and "end") have been removed
    at cleanRangeOptions (/home/ubuntu/src/github.com/yuiseki/geocoder-ja/src/node_modules/level-packager/node_modules/abstract-leveldown/abstract-leveldown.js:257:13)
    at DeferredLevelDOWN.AbstractLevelDOWN._setupIteratorOptions (/home/ubuntu/src/github.com/yuiseki/geocoder-ja/src/node_modules/level-packager/node_modules/abstract-leveldown/abstract-leveldown.js:238:13)
    at DeferredLevelDOWN.AbstractLevelDOWN.iterator (/home/ubuntu/src/github.com/yuiseki/geocoder-ja/src/node_modules/level-packager/node_modules/abstract-leveldown/abstract-leveldown.js:280:18)
    at LevelUP.readStream.LevelUP.createReadStream (/home/ubuntu/src/github.com/yuiseki/geocoder-ja/src/node_modules/level-packager/node_modules/levelup/lib/levelup.js:284:37)
    at /home/ubuntu/src/github.com/yuiseki/geocoder-ja/src/node_modules/level-geospatial/lib/level-geospatial.js:115:7
```

## How to check
- rewrite `/node_modules/level-geospatial/lib/level-geospatial.js`
- see correctly work it.

## Document
- https://github.com/Level/levelup/blob/master/UPGRADING.md#500

